### PR TITLE
added exports path for index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.2",
   "description": "FileSystem Tree",
   "type": "module",
+  "exports": "./index.js",
   "scripts": {
     "documentation": "documentation",
     "test": "NODE_OPTIONS=--experimental-vm-modules npx jest"


### PR DESCRIPTION
Приветствую!

На последних версия ноды (>=16) всплывает ворнинг (`DeprecationWarning: No "main" or "exports" field defined in the package.json`) о том, что в `package.json` нет объявленного экспорта из пакета.

Примеры обращений от студентов: [раз](https://ru.hexlet.io/topics/69395), [два](https://ru.hexlet.io/topics/55028).

_Сами ворнинги до изменений в `package.json`_
<img width="732" alt="Screenshot 2023-11-15 at 23 12 23" src="https://github.com/hexlet-components/js-immutable-fs-trees/assets/87711559/70f07148-2bb2-4d6e-b67b-9fb41e381282">
<img width="732" alt="Screenshot 2023-11-15 at 23 09 32" src="https://github.com/hexlet-components/js-immutable-fs-trees/assets/87711559/ecf05c9e-c864-4e1f-b581-d2c884a126e3">

Этим пулл-реквестом убираю ворнинги на последних версиях ноды.